### PR TITLE
Update to v2-master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ echo "**** fetch organizr ****" && \
 mkdir -p\
 	/var/www/html && \
 if [ -z ${ORGANIZR_COMMIT+x} ]; then \
-	ORGANIZR_COMMIT=$(curl -sX GET "https://api.github.com/repos/causefx/Organizr/branches/v1-master" \
+	ORGANIZR_COMMIT=$(curl -sX GET "https://api.github.com/repos/causefx/Organizr/branches/v2-master" \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
 fi && \
 curl -o \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -24,7 +24,7 @@ echo "**** fetch organizr ****" && \
 mkdir -p\
 	/var/www/html && \
 if [ -z ${ORGANIZR_COMMIT+x} ]; then \
-	ORGANIZR_COMMIT=$(curl -sX GET "https://api.github.com/repos/causefx/Organizr/branches/v1-master" \
+	ORGANIZR_COMMIT=$(curl -sX GET "https://api.github.com/repos/causefx/Organizr/branches/v2-master" \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
 fi && \
 curl -o \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -24,7 +24,7 @@ echo "**** fetch organizr ****" && \
 mkdir -p\
 	/var/www/html && \
 if [ -z ${ORGANIZR_COMMIT+x} ]; then \
-	ORGANIZR_COMMIT=$(curl -sX GET "https://api.github.com/repos/causefx/Organizr/branches/v1-master" \
+	ORGANIZR_COMMIT=$(curl -sX GET "https://api.github.com/repos/causefx/Organizr/branches/v2-master" \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
 fi && \
 curl -o \


### PR DESCRIPTION
Organizr released v2 and changed their default branch to v2-master.
This PR updates the 3 dockerfiles to fetch v2-master instead of v1-master.