### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.9
+FROM lsiobase/nginx:3.10
 
 # set version label
 ARG ORGANIZR_COMMIT

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.9
+FROM lsiobase/nginx:arm64v8-3.10
 
 # set version label
 ARG ORGANIZR_COMMIT

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.9
+FROM lsiobase/nginx:arm32v7-3.10
 
 # set version label
 ARG ORGANIZR_COMMIT

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,6 +43,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "18.04.19:", desc: "Fix new install not working." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "26.02.19:", desc: "Upgrade packages during install to prevent mismatch with baseimage." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

This one shows many errors on the landing page, not sure if we can bump to newer PHP versions. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.