### PR TITLE
Rebase to lsiobase/nginx:3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.9
+FROM lsiobase/nginx:3.12
 
 # set version label
 ARG ORGANIZR_COMMIT

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.9
+FROM lsiobase/nginx:arm64v8-3.12
 
 # set version label
 ARG ORGANIZR_COMMIT

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.9
+FROM lsiobase/nginx:arm32v7-3.12
 
 # set version label
 ARG ORGANIZR_COMMIT

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.09.20:** - Rebase to Alpine 3.12
 * **18.04.19:** - Fix new install not working.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **26.02.19:** - Upgrade packages during install to prevent mismatch with baseimage.


### PR DESCRIPTION
This is built off of an older image, this PR is to upgrade to version 3.12 of Alpine